### PR TITLE
fix : statutValidation in concept/{id} from Boolean to Publié/Provisoire

### DIFF
--- a/src/main/resources/queries/concepts/getDetailedConcept.ftlh
+++ b/src/main/resources/queries/concepts/getDetailedConcept.ftlh
@@ -9,8 +9,8 @@ WHERE {
     FILTER (lang(?prefLabelLg2) = '${LG2}') .
     ?uri dcterms:created ?dateCreation .
     ?uri dcterms:modified ?dateMiseAjour .
-    ?uri insee:isValidated ?statutValidation .
-    OPTIONAL { ?uri dcterms:valid ?dateFinValidite . } .
+    ?uri insee:isValidated ?isValidated .
+    BIND( if(?isValidated,"Publié","Provisoire") as ?statutValidation )    OPTIONAL { ?uri dcterms:valid ?dateFinValidite . } .
     OPTIONAL {
         ?uri skos:definition ?definition .
         ?definition dcterms:language "fr"^^xsd:language .


### PR DESCRIPTION
Précédemment, les deux méthodes de magma sur les concepts retournent "statutValidation": "true"/"false".
Désormais on a  :
- "true" --> "Publiée"
- "false"--> "Provisoire"