### PR TITLE
fix: Provisoire -> Provisoire,jamais publiée for statutValidation

### DIFF
--- a/src/main/resources/queries/concepts/getAllConcepts.ftlh
+++ b/src/main/resources/queries/concepts/getAllConcepts.ftlh
@@ -5,5 +5,5 @@ WHERE {
     BIND(STRAFTER(STR(?concept),'/concepts/definition/') AS ?id) .
     ?concept dcterms:modified ?dateMiseAJour .
     ?concept insee:isValidated ?isValidated .
-    BIND( if(?isValidated,"Publié","Provisoire") as ?statutValidation )
+    BIND( if(?isValidated,"Publié","Provisoire, jamais publiée") as ?statutValidation )
 }

--- a/src/main/resources/queries/concepts/getDetailedConcept.ftlh
+++ b/src/main/resources/queries/concepts/getDetailedConcept.ftlh
@@ -10,7 +10,7 @@ WHERE {
     ?uri dcterms:created ?dateCreation .
     ?uri dcterms:modified ?dateMiseAjour .
     ?uri insee:isValidated ?isValidated .
-    BIND( if(?isValidated,"Publié","Provisoire") as ?statutValidation )    OPTIONAL { ?uri dcterms:valid ?dateFinValidite . } .
+    BIND( if(?isValidated,"Publié","Provisoire, jamais publiée") as ?statutValidation )    OPTIONAL { ?uri dcterms:valid ?dateFinValidite . } .
     OPTIONAL {
         ?uri skos:definition ?definition .
         ?definition dcterms:language "fr"^^xsd:language .


### PR DESCRIPTION
Actuellement les deux méthodes de magma sur les concepts retournent "statutValidation": "true"/"false".

Pour aligner sur le contenu sur les autres objets, est-ce que pourrait déjà dans un premier temps remplacer comme suit:

- "true" --> "Publiée"
- "false"--> "Provisoire, jamais publiée"