### PR TITLE
168 ajouter champ relation get dataset by

### DIFF
--- a/src/main/java/fr/insee/rmes/modelSwagger/dataset/DataSetModelSwagger.java
+++ b/src/main/java/fr/insee/rmes/modelSwagger/dataset/DataSetModelSwagger.java
@@ -58,7 +58,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
         "structure",
         "numObservations",
         "numSeries",
-        "wasDerivedFrom"
+        "wasDerivedFrom",
+        "relations"
 })
 
 @Generated("jsonschema2pojo")
@@ -142,6 +143,8 @@ public class DataSetModelSwagger implements Serializable  {
     private Integer numObservations;
     @JsonProperty("numSeries")
     private Integer numSeries;
+    @JsonProperty("relations")
+    private List<String> relations;
 
 
 

--- a/src/main/java/fr/insee/rmes/services/datasets/DataSetsImpl.java
+++ b/src/main/java/fr/insee/rmes/services/datasets/DataSetsImpl.java
@@ -206,6 +206,12 @@ public class DataSetsImpl extends RdfService implements DataSetsServices {
             landingPage.add(landingPage2);
             reponse.setLandingPage(landingPage);
         }
+        //récupération de la liste de relations
+        if (!catalogue_result.optString("relations").isEmpty()){
+            List<String> relationsUris = List.of(catalogue_result.getString("relations").split(","));
+            reponse.setRelations(relationsUris);
+        }
+
         //récupération du processStep
         if (codes_result.has("codeProcessStep")) {
             String codeProcessStepValue = codes_result.getString("codeProcessStep");

--- a/src/main/resources/queries/dataSets/getDataSetById_catalogue.ftlh
+++ b/src/main/resources/queries/dataSets/getDataSetById_catalogue.ftlh
@@ -14,6 +14,7 @@ SELECT DISTINCT ?id ?uri ?titleLg1 ?titleLg2
                 (GROUP_CONCAT(DISTINCT ?wasGeneratedBy; separator=" , ") AS ?operationStat)
                 (GROUP_CONCAT(DISTINCT ?creators; separator=" , ") AS ?creators)
                 (GROUP_CONCAT(DISTINCT ?wasDerivedFromS; separator=" , ") AS ?wasDerivedFromS)
+                (GROUP_CONCAT(DISTINCT ?relations; separator=",") AS ?relations)
 FROM <${DATASETS_GRAPH}>
 FROM <${ORGANISATIONS_GRAPH}>
 FROM <${ORGANISATIONS_GRAPH}/insee>
@@ -40,6 +41,10 @@ WHERE {
              ^foaf:primaryTopic/dcterms:modified ?catalogRecordModified ;
              ^foaf:primaryTopic/dcterms:created ?catalogRecordCreated .
     }
+
+    OPTIONAL {
+            ?uri dcterms:relation ?relations ;
+        }
 
     BIND(IF(?isValidated = "Unpublished", "Provisoire, jamais publiée", "Publiée") AS ?statutValidation)
 

--- a/src/test/java/fr/insee/rmes/persistence/RdfServiceTest.java
+++ b/src/test/java/fr/insee/rmes/persistence/RdfServiceTest.java
@@ -63,17 +63,6 @@ class RdfServiceTest {
         assertEquals("Provisoire, déjà publiée", result3);
     }
 
-    @Test
-    @DisplayName("Test de BuildRequest")
-    void buildRequestTest() {
-        //GIVEN
-        //WHEN
-        //THEN
-
-    }
-
-
-
 
 
 }

--- a/src/test/java/fr/insee/rmes/services/datasets/DataSetsImplTest.java
+++ b/src/test/java/fr/insee/rmes/services/datasets/DataSetsImplTest.java
@@ -162,15 +162,14 @@ class DataSetsImplTest {
                 .hasMessageContaining("Non existent dataset identifier");
     }
 
-    private static final String CATALOGUE_RESULT_RELATIONS = "{\"relations\":\"http://www.insee.fr,http://www.rdf.insee.fr\"}";
-    private static final String EXPECTED_RELATIONS = "[\"http://www.insee.fr\", \"http://www.rdf.insee.fr\"]";
+
     @Test
     void testPresenceRelationsPuisAjout_checkFieldIsAdded() throws RmesException, JsonProcessingException {
 
         var datasetImpl=new DataSetsImpl();
         var response = new DataSetModelSwagger();
-        var catalogue_result = new JSONObject(CATALOGUE_RESULT_RELATIONS);
-        var expected = new JSONArray(EXPECTED_RELATIONS);
+        var catalogue_result = new JSONObject(DataSetsUtilsTest.CATALOGUE_RESULT_RELATIONS);
+        var expected = new JSONArray(DataSetsUtilsTest.EXPECTED_RELATIONS);
         datasetImpl.testPresenceVariablePuisAjout(response,catalogue_result,new JSONObject(),new JSONObject(),new JSONObject(),new JSONObject());
         assertThat(response.getRelations().get(0)).isEqualTo(expected.get(0));
         assertThat(response.getRelations().get(1)).isEqualTo(expected.get(1));

--- a/src/test/java/fr/insee/rmes/services/datasets/DataSetsImplTest.java
+++ b/src/test/java/fr/insee/rmes/services/datasets/DataSetsImplTest.java
@@ -162,6 +162,19 @@ class DataSetsImplTest {
                 .hasMessageContaining("Non existent dataset identifier");
     }
 
+    private static final String CATALOGUE_RESULT_RELATIONS = "{\"relations\":\"http://www.insee.fr,http://www.rdf.insee.fr\"}";
+    private static final String EXPECTED_RELATIONS = "[\"http://www.insee.fr\", \"http://www.rdf.insee.fr\"]";
+    @Test
+    void testPresenceRelationsPuisAjout_checkFieldIsAdded() throws RmesException, JsonProcessingException {
+
+        var datasetImpl=new DataSetsImpl();
+        var response = new DataSetModelSwagger();
+        var catalogue_result = new JSONObject(CATALOGUE_RESULT_RELATIONS);
+        var expected = new JSONArray(EXPECTED_RELATIONS);
+        datasetImpl.testPresenceVariablePuisAjout(response,catalogue_result,new JSONObject(),new JSONObject(),new JSONObject(),new JSONObject());
+        assertThat(response.getRelations().get(0)).isEqualTo(expected.get(0));
+        assertThat(response.getRelations().get(1)).isEqualTo(expected.get(1));
+    }
 
 
 }

--- a/src/test/java/fr/insee/rmes/services/structures/StructuresImplTest.java
+++ b/src/test/java/fr/insee/rmes/services/structures/StructuresImplTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import fr.insee.rmes.persistence.RepositoryGestion;
 import fr.insee.rmes.services.utils.ResponseUtilsTest;
+import fr.insee.rmes.services.utils.StructuresUtilsTest;
 import fr.insee.rmes.stubs.FreeMarkerUtilsStub;
 import fr.insee.rmes.utils.config.Config;
 import fr.insee.rmes.utils.exceptions.RmesException;
@@ -26,61 +27,6 @@ import static org.mockito.Mockito.when;
 @Nested
 @ExtendWith(MockitoExtension.class)
 class StructuresImplTest {
-    public static final String SLICE_STRUCTURE = """
-        [
-            {
-                "componentIds":"d0996,d0997",
-                "prefLabelLg1":"Séries temporelles",
-                "prefLabelLg2":"Time series",
-                "sliceKey":"http://bauhaus/structuresDeDonnees/structure/dsd0995/sk1000",
-                "typeSliceKey":"TS"
-            },
-            {
-                "componentIds":"d0996,d0995",
-                "prefLabelLg1":"Slice par région",
-                "prefLabelLg2":"Slice by area",
-                "sliceKey":"http://bauhaus/structuresDeDonnees/structure/dsd0995/sk1001"
-            }
-        ]
-        """;
-    public final String EXPECTED_SLICE_STRUCTURE = """
-            [
-                {
-                    "composants":[
-                        "d0996",
-                        "d0997"
-                    ],
-                    "label":[
-                        {
-                            "langue":"fr",
-                            "contenu":"Séries temporelles"
-                        },
-                        {
-                            "langue":"en",
-                            "contenu":"Time series"
-                        }
-                    ],
-                    "type":"TS"
-                },
-                {
-                    "composants":[
-                        "d0996",
-                        "d0995"
-                    ],
-                    "label":
-                        [
-                            {"langue":"fr",
-                            "contenu":"Slice par région"
-                            },
-                            {
-                            "langue":"en",
-                            "contenu":"Slice by area"
-                            }
-                        ]
-                    }
-                ]
-            """
-            ;
 
 
     @Mock
@@ -145,9 +91,9 @@ class StructuresImplTest {
 
     @Test
     void getStructureWithSliceKeys_shouldReturnExpectedStructure() throws RmesException, JsonProcessingException {
-        JSONArray mockJSON = new JSONArray(SLICE_STRUCTURE);
+        JSONArray mockJSON = new JSONArray(StructuresUtilsTest.SLICE_STRUCTURE);
         when(repoGestion.getResponseAsArray("getStructureSliceKeys.ftlh")).thenReturn(mockJSON);
-        assertThat(MAPPER.readTree(structuresImpl.getSlice("1"))).isEqualTo(MAPPER.readTree(EXPECTED_SLICE_STRUCTURE.toString()));
+        assertThat(MAPPER.readTree(structuresImpl.getSlice("1"))).isEqualTo(MAPPER.readTree(StructuresUtilsTest.EXPECTED_SLICE_STRUCTURE.toString()));
     }
 
 }

--- a/src/test/java/fr/insee/rmes/services/utils/DataSetsUtilsTest.java
+++ b/src/test/java/fr/insee/rmes/services/utils/DataSetsUtilsTest.java
@@ -79,4 +79,7 @@ public class DataSetsUtilsTest {
             ]
             """
             ;
+
+    public static final String CATALOGUE_RESULT_RELATIONS = "{\"relations\":\"http://www.insee.fr,http://www.rdf.insee.fr\"}";
+    public static final String EXPECTED_RELATIONS = "[\"http://www.insee.fr\", \"http://www.rdf.insee.fr\"]";
 }

--- a/src/test/java/fr/insee/rmes/services/utils/StructuresUtilsTest.java
+++ b/src/test/java/fr/insee/rmes/services/utils/StructuresUtilsTest.java
@@ -1,0 +1,60 @@
+package fr.insee.rmes.services.utils;
+
+public class StructuresUtilsTest {
+    public static final String SLICE_STRUCTURE = """
+        [
+            {
+                "componentIds":"d0996,d0997",
+                "prefLabelLg1":"Séries temporelles",
+                "prefLabelLg2":"Time series",
+                "sliceKey":"http://bauhaus/structuresDeDonnees/structure/dsd0995/sk1000",
+                "typeSliceKey":"TS"
+            },
+            {
+                "componentIds":"d0996,d0995",
+                "prefLabelLg1":"Slice par région",
+                "prefLabelLg2":"Slice by area",
+                "sliceKey":"http://bauhaus/structuresDeDonnees/structure/dsd0995/sk1001"
+            }
+        ]
+        """;
+    public static final String EXPECTED_SLICE_STRUCTURE = """
+            [
+                {
+                    "composants":[
+                        "d0996",
+                        "d0997"
+                    ],
+                    "label":[
+                        {
+                            "langue":"fr",
+                            "contenu":"Séries temporelles"
+                        },
+                        {
+                            "langue":"en",
+                            "contenu":"Time series"
+                        }
+                    ],
+                    "type":"TS"
+                },
+                {
+                    "composants":[
+                        "d0996",
+                        "d0995"
+                    ],
+                    "label":
+                        [
+                            {"langue":"fr",
+                            "contenu":"Slice par région"
+                            },
+                            {
+                            "langue":"en",
+                            "contenu":"Slice by area"
+                            }
+                        ]
+                    }
+                ]
+            """
+            ;
+
+}


### PR DESCRIPTION
issue #168 
question : 
in DataSetsImplTest, if I write

> assertThat(response.getRelations()).isEqualTo(expected);

the test is wrong because of a blank between the 2 relations.
Does it exist a better way to do ?
